### PR TITLE
Reset to the previous state if a new state is cancelled.

### DIFF
--- a/lib/location.js
+++ b/lib/location.js
@@ -85,6 +85,7 @@ var go = function (url, options) {
 
   runHandlers('go', state);
 
+  var previous = current;
   if (set(state)) {
     Deps.afterFlush(function () {
       // if after we've flushed if nobody has cancelled the state then change
@@ -98,6 +99,9 @@ var go = function (url, options) {
           else
             history.pushState(options.historyState, null, url);
         }
+      } else {
+        // Reset the state. We don't need to update the URL thereafter since it hasn't changed.
+        set(previous);
       }
     });
   }


### PR DESCRIPTION
Otherwise the current state will be inconsistent e.g. `Iron.Location.get().path` will not
reflect the actual URL.